### PR TITLE
Fix build bustage.

### DIFF
--- a/dom/media/gmp/widevine-adapter/WidevineUtils.h
+++ b/dom/media/gmp/widevine-adapter/WidevineUtils.h
@@ -51,6 +51,10 @@ public:
   explicit CDMWrapper(cdm::ContentDecryptionModule_9* aCDM,
                       WidevineDecryptor* aDecryptor);
   cdm::ContentDecryptionModule_9* GetCDM() const { return mCDM; }
+  void OnStorageId(uint32_t aVersion, const uint8_t* aStorageId,
+                   uint32_t aStorageIdSize) {
+    mCDM->OnStorageId(aVersion, aStorageId, aStorageIdSize);
+  }
 private:
   ~CDMWrapper();
   cdm::ContentDecryptionModule_9* mCDM;


### PR DESCRIPTION
Here's the build bustage fix for the CDM work that makes it work with Widevine 4.9 -- the state I've now merged to UXP-master to build a 4.9-fixed Basilisk. Still needs work for 4.10, but at least having this repaired is a good thing.